### PR TITLE
Fix link that 404s

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -73,7 +73,7 @@ See :ref:`sphinx-analysis` for details.
 Kudos
 -----
 This little tool borrows a lot of ideas from the
-`performance script <https://sphinx-performance.readthedocs.io/en/latest/performance/index.html>`_
+`performance script <https://sphinxcontrib-needs.readthedocs.io/en/latest/performance/index.html>`_
 of `Sphinx-Needs <https://sphinx-needs.com>`_.
 
 


### PR DESCRIPTION
I'm not sure if this was the intended page that was meant to be linked to, but the current link 404s and this looked like the appropriate fix.