### PR TITLE
:bug: Fix needs project contrib name

### DIFF
--- a/sphinx_performance/projects/needs/requirements.template
+++ b/sphinx_performance/projects/needs/requirements.template
@@ -1,3 +1,3 @@
 sphinx=={{sphinx}}
-sphinxcontrib-needs
+sphinx-needs
 sphinxcontrib-plantuml


### PR DESCRIPTION
Fixes the SN dependency for the `needs` project.